### PR TITLE
feat[#14]:장례 검색 기능 구현

### DIFF
--- a/src/main/java/growthon/withtail_be/config/SecurityConfig.java
+++ b/src/main/java/growthon/withtail_be/config/SecurityConfig.java
@@ -45,7 +45,8 @@ public class SecurityConfig {
                         .requestMatchers(
                                 "/test/**",
                                 "/auth/**",
-                                "/oauth/**"
+                                "/oauth/**",
+                                "/api/**"
                         ).permitAll()
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/growthon/withtail_be/domain/funeral/controller/FuneralController.java
+++ b/src/main/java/growthon/withtail_be/domain/funeral/controller/FuneralController.java
@@ -1,0 +1,30 @@
+package growthon.withtail_be.domain.funeral.controller;
+
+import growthon.withtail_be.domain.funeral.dto.FuneralSearchResponse;
+import growthon.withtail_be.domain.funeral.service.FuneralService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/funerals")
+public class FuneralController {
+
+    private final FuneralService funeralService;
+
+    @GetMapping
+    public Page<FuneralSearchResponse> search(
+            @RequestParam(required = false) String keyword,
+            @RequestParam(required = false) String sido,
+            @RequestParam(required = false) String sigungu,
+            @PageableDefault(size = 10) Pageable pageable
+    ) {
+        return funeralService.search(keyword, sido, sigungu, pageable);
+    }
+}

--- a/src/main/java/growthon/withtail_be/domain/funeral/dto/FuneralSearchResponse.java
+++ b/src/main/java/growthon/withtail_be/domain/funeral/dto/FuneralSearchResponse.java
@@ -1,0 +1,34 @@
+package growthon.withtail_be.domain.funeral.dto;
+
+import growthon.withtail_be.domain.funeral.entity.Funeral;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class FuneralSearchResponse {
+
+    private Long id;
+    private String name;
+    private String address;
+    private String phone;
+
+    private Double rating;
+    private Integer reviewCount;
+
+    private Integer minPrice;
+    private Integer maxPrice;
+
+    public static FuneralSearchResponse from(Funeral funeral) {
+        return FuneralSearchResponse.builder()
+                .id(funeral.getId())
+                .name(funeral.getName())
+                .address(funeral.getAddress())
+                .phone(funeral.getPhone())
+                .rating(funeral.getRating())
+                .reviewCount(funeral.getReviewCount())
+                .minPrice(funeral.getMinPrice())
+                .maxPrice(funeral.getMaxPrice())
+                .build();
+    }
+}

--- a/src/main/java/growthon/withtail_be/domain/funeral/entity/Funeral.java
+++ b/src/main/java/growthon/withtail_be/domain/funeral/entity/Funeral.java
@@ -1,0 +1,51 @@
+package growthon.withtail_be.domain.funeral.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "funerals")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Funeral {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 업체명
+    @Column(nullable = false)
+    private String name;
+
+    // 지역(시/도, 시/군/구)
+    @Column(nullable = false)
+    private String sido;
+
+    @Column(nullable = false)
+    private String sigungu;
+
+    // 주소/연락처
+    @Column(nullable = false)
+    private String address;
+
+    private String phone;
+
+    // 리스트 표시용
+    private Double rating;
+    private Integer reviewCount;
+
+    // 가격대(임시): 최저/최고
+    private Integer minPrice;
+    private Integer maxPrice;
+}

--- a/src/main/java/growthon/withtail_be/domain/funeral/repository/FuneralRepository.java
+++ b/src/main/java/growthon/withtail_be/domain/funeral/repository/FuneralRepository.java
@@ -1,0 +1,26 @@
+package growthon.withtail_be.domain.funeral.repository;
+
+import growthon.withtail_be.domain.funeral.entity.Funeral;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface FuneralRepository extends JpaRepository<Funeral, Long> {
+
+    @Query("""
+        select f
+        from Funeral f
+        where (:keyword is null or :keyword = '' 
+               or lower(f.name) like lower(concat('%', :keyword, '%')))
+          and (:sido is null or :sido = '' or f.sido = :sido)
+          and (:sigungu is null or :sigungu = '' or f.sigungu = :sigungu)
+    """)
+    Page<Funeral> search(
+            @Param("keyword") String keyword,
+            @Param("sido") String sido,
+            @Param("sigungu") String sigungu,
+            Pageable pageable
+    );
+}

--- a/src/main/java/growthon/withtail_be/domain/funeral/service/FuneralService.java
+++ b/src/main/java/growthon/withtail_be/domain/funeral/service/FuneralService.java
@@ -1,0 +1,20 @@
+package growthon.withtail_be.domain.funeral.service;
+
+import growthon.withtail_be.domain.funeral.dto.FuneralSearchResponse;
+import growthon.withtail_be.domain.funeral.repository.FuneralRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class FuneralService {
+
+    private final FuneralRepository funeralRepository;
+
+    public Page<FuneralSearchResponse> search(String keyword, String sido, String sigungu, Pageable pageable) {
+        return funeralRepository.search(keyword, sido, sigungu, pageable)
+                .map(FuneralSearchResponse::from);
+    }
+}


### PR DESCRIPTION
#️⃣연관된 이슈
ex) #14 

📝작업 내용
장례 검색 기능을 구현 했습니다.
- 장례식장 검색 API 구현
- 키워드 / 지역(시*도시, 시*군*구) 기반 검색 기능 추가
- 페이징 처리(Pageable) 적용
- Entity → DTO 변환 로직 구현
- 병원 검색 구조와 동일한 패턴으로 구현하여 추후 유지보수 용이하게 설계함.
##
## 💊 테스트 방법
- Postman에서 'GET /api/funerals' 호출
- 검색 조건 테스트
  - 키워드 검색: 'http://localhost:8080/api/funerals?keyword=무지개 [예시]
  - 지역 필터(시/도시만): http://localhost:8080/api/funerals?sido=서울 [예시]
  - 지역 필터(시/도시 + 시/군/구): http://localhost:8080/api/funerals?sido=서울&sigungu=강남구 [예시]
- 페이징 테스트 
  - http://localhost:8080/api/funerals?page=0&size=10 [예시]
## 
💬리뷰 요구사항(선택)
 -장례 Entity 필드 구성(가격 범위, 평점 등)이 적절한지 확인 부탁드립니다.