### PR TITLE
feat[#15]:병원 검색 기능 구현

### DIFF
--- a/src/main/java/growthon/withtail_be/config/SecurityConfig.java
+++ b/src/main/java/growthon/withtail_be/config/SecurityConfig.java
@@ -33,6 +33,7 @@ public class SecurityConfig {
                         .requestMatchers(
                                 "/test/**"
                         ).permitAll()
+                        .requestMatchers("/api/**").permitAll()
                         .anyRequest().authenticated()
                 );
 

--- a/src/main/java/growthon/withtail_be/domain/hospital/controller/HospitalController.java
+++ b/src/main/java/growthon/withtail_be/domain/hospital/controller/HospitalController.java
@@ -1,0 +1,33 @@
+package growthon.withtail_be.domain.hospital.controller;
+
+import growthon.withtail_be.domain.hospital.dto.HospitalSearchResponse;
+import growthon.withtail_be.domain.hospital.service.HospitalService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+// 병원 검색 API 진입점
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/hospitals")
+public class HospitalController {
+
+
+    private final HospitalService hospitalService;
+
+    // GET /api/hospitals?keyword=&sido=&sigungu=&page=&size=
+    @GetMapping
+    public Page<HospitalSearchResponse> search(
+            @RequestParam(required = false) String keyword,
+            @RequestParam(required = false) String sido,
+            @RequestParam(required = false) String sigungu,
+            @PageableDefault(size = 10) Pageable pageable
+    ) {
+        return hospitalService.search(keyword, sido, sigungu, pageable);
+    }
+}

--- a/src/main/java/growthon/withtail_be/domain/hospital/dto/HospitalSearchResponse.java
+++ b/src/main/java/growthon/withtail_be/domain/hospital/dto/HospitalSearchResponse.java
@@ -1,0 +1,33 @@
+package growthon.withtail_be.domain.hospital.dto;
+
+import growthon.withtail_be.domain.hospital.entity.Hospital;
+import lombok.Builder;
+import lombok.Getter;
+
+// 리스트 응답용 DTO (Entity 그대로 노출하지 않기)
+@Getter
+@Builder
+public class HospitalSearchResponse {
+
+    private Long id;
+    private String name;
+    private String address;
+    private String phone;
+
+    private Double rating;
+    private Integer reviewCount;
+    private Boolean is24;
+
+    // Entity -> DTO 변환
+    public static HospitalSearchResponse from(Hospital hospital) {
+        return HospitalSearchResponse.builder()
+                .id(hospital.getId())
+                .name(hospital.getName())
+                .address(hospital.getAddress())
+                .phone(hospital.getPhone())
+                .rating(hospital.getRating())
+                .reviewCount(hospital.getReviewCount())
+                .is24(hospital.getIs24h())
+                .build();
+    }
+}

--- a/src/main/java/growthon/withtail_be/domain/hospital/entity/Hospital.java
+++ b/src/main/java/growthon/withtail_be/domain/hospital/entity/Hospital.java
@@ -1,0 +1,52 @@
+package growthon.withtail_be.domain.hospital.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+// 병원 테이블(hospitals)과 매핑되는 엔티티
+@Entity
+@Table(name = "hospitals")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED) // JPA 기본 생성자
+@AllArgsConstructor
+@Builder
+public class Hospital {
+
+    // PK (auto_increment)
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 병원명 (키워드 검색 대상(
+    @Column(nullable = false)
+    private String name;
+
+    // 지역 필터용 (시/도, 시/군/구)
+    @Column(nullable = false)
+    private String sido;
+
+    @Column(nullable = false)
+    private String sigungu;
+
+    // 화면 표시용 주소/연락처
+    @Column(nullable = false)
+    private String address;
+
+    private String phone;
+
+    // 리스트 카드 표시용(없으면 null/0 가능)
+    private Double rating;
+    private Integer reviewCount;
+
+    // 24시간 여부
+    private Boolean is24h;
+}

--- a/src/main/java/growthon/withtail_be/domain/hospital/repository/HospitalRepository.java
+++ b/src/main/java/growthon/withtail_be/domain/hospital/repository/HospitalRepository.java
@@ -1,0 +1,28 @@
+package growthon.withtail_be.domain.hospital.repository;
+
+import growthon.withtail_be.domain.hospital.entity.Hospital;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+// 병원 검색 쿼리 담당 (조건 + 페이징)
+public interface HospitalRepository extends JpaRepository<Hospital, Long> {
+
+    // keyword/sido/sigungu가 없으면 해당 조건은 무시
+    @Query("""
+        select h
+        from Hospital h
+        where (:keyword is null or :keyword = '' 
+               or lower(h.name) like lower(concat('%', :keyword, '%')))
+          and (:sido is null or :sido = '' or h.sido = :sido)
+          and (:sigungu is null or :sigungu = '' or h.sigungu = :sigungu)
+    """)
+    Page<Hospital> search(
+            @Param("keyword") String keyword,
+            @Param("sido") String sido,
+            @Param("sigungu") String sigungu,
+            Pageable pageable
+    );
+}

--- a/src/main/java/growthon/withtail_be/domain/hospital/service/HospitalService.java
+++ b/src/main/java/growthon/withtail_be/domain/hospital/service/HospitalService.java
@@ -1,0 +1,21 @@
+package growthon.withtail_be.domain.hospital.service;
+
+import growthon.withtail_be.domain.hospital.dto.HospitalSearchResponse;
+import growthon.withtail_be.domain.hospital.repository.HospitalRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+//검색 로직(조회 + DTO 변환)
+@Service
+@RequiredArgsConstructor
+public class HospitalService {
+
+    private final HospitalRepository hospitalRepository;
+
+    public Page<HospitalSearchResponse> search(String keyword, String sido, String sigungu, Pageable pageable) {
+        return hospitalRepository.search(keyword,sido,sigungu,pageable)
+                .map(HospitalSearchResponse::from);
+    }
+}


### PR DESCRIPTION
#️⃣연관된 이슈
ex) #15 

📝작업 내용
병원 검색 기능 구현을 했습니다.
- 동물병원 검색 API 구현
- 키워드 기반 병원명 검색 기능 추가
- 지역 (시•도, 시•군•구) 필터링 기능 구현
- Pageable을 활용한 페이징 처리
- Entity → DTO 변환 로직 분리하여 응답 구조 정리
##
💊 테스트 방법
- Postman에서 'GET /api/hospital' 호출
- 검색 조건 테스트
  - 병원 전체 조회: GET | http://localhost:8080/api/hospitals
  - 키워드 검색: http://localhost:8080/api/hospitals?keyword=24시
  - 지역 필터 검색(시/도시만): http://localhost:8080/api/hospitals?sido=서울 [예시]
  - 시/도 + 시/군/구 필터: http://localhost:8080/api/hospitals?sido=서울&sigungu=강남구[예시]
 - 페이징 테스트
   - 2페이지, 5개씩 (예시)
   -  http://localhost:8080/api/hospitals?page=1&size=5
   - 의미: page: 0부터 시작, size: 한 페이지에 몇 개 보여줄지
##
💬리뷰 요구사항(선택)
- 병원 검색 쿼리 조건 처리 방식이 적절한지 확인 부탁드립니다.
- DB는 일단 임의로 넣었습니다.
